### PR TITLE
Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Fineract CN Core Command [![Build Status](https://api.travis-ci.com/apache/fineract-cn-command.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-command)
+# Apache Fineract CN Core Command
 
 This project is an umbrella for all Apache Fineract CN Core components.
 


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.